### PR TITLE
Stop and bring down everything at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,12 @@ antivirus:
 
 .PHONY: up
 up:
-	@${DC_ANTIVIRUS} docker compose ${DC_PROFILES} up
+	${DC_ANTIVIRUS} docker compose ${DC_PROFILES} up
 
 .PHONY: stop
-stop:
+stop: beat antivirus
 	docker compose ${DC_PROFILES} stop
+
+.PHONY: down
+down: beat antivirus
+	docker compose ${DC_PROFILES} down


### PR DESCRIPTION
If you run all of the apps (eg `make beat antivirus up`) and then destroy them via eg `docker compose down/stop`, the celery-beat and antivirus containers don't get destroyed because they are excluded by the docker-compose profiles.

Update the make steps (and add a full down) to clean everything up properly.