### PR TITLE
Changing postgres version to 15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   db:
-    image: postgres:11-bullseye
+    image: postgres:15-bullseye
     container_name: db
     volumes:
       - ./data/db:/var/lib/postgresql/data


### PR DESCRIPTION
We are upgrading our postgres version so the apps on notify will operate this version of postgres after the migration from PaaS. local envs should also start using this version.