### PR TITLE
Add the sms-provider-stub as an optional container to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,21 @@ antivirus:
 	$(eval export DC_PROFILES=${DC_PROFILES} --profile antivirus)
 	@true
 
+.PHONY: sms-provider-stub
+sms-provider-stub:
+	$(eval export DC_SMS_PROVIDER_STUB_MMG=MMG_URL=http://host.docker.internal:6300/mmg)
+	$(eval export DC_SMS_PROVIDER_STUB_FIRETEXT=FIRETEXT_URL=http://host.docker.internal:6300/firetext)
+	$(eval export DC_PROFILES=${DC_PROFILES} --profile sms-provider-stub)
+	@true
+
 .PHONY: up
 up:
-	${DC_ANTIVIRUS} docker compose ${DC_PROFILES} up
+	${DC_SMS_PROVIDER_STUB_MMG} ${DC_SMS_PROVIDER_STUB_FIRETEXT} ${DC_ANTIVIRUS} docker compose ${DC_PROFILES} up
 
 .PHONY: stop
-stop: beat antivirus
+stop: beat antivirus sms-provider-stub
 	docker compose ${DC_PROFILES} stop
 
 .PHONY: down
-down: beat antivirus
+down: beat antivirus sms-provider-stub
 	docker compose ${DC_PROFILES} down

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This README needs some love and may not be in an intuitive order. Please read th
 
 The default way to bring up a local version of GOV.UK Notify, after following setup, is to run `make up` from the root of this repository. This will start notify-api, notify-api-celery, notify-admin, template-preview-api, template-preview-celery, document-download-api, and document-download-preview, which will cover 95%+ of the things you need.
 
-To also run and enable antivirus scanning, run `make antivirus up`. To run and enable celery-beat for regularly-scheduled tasks, run `make beat up`. These can be combined to `make beat antivirus up` to run *everything*.
+To also run and enable antivirus scanning, run `make antivirus up`. To run and enable celery-beat for regularly-scheduled tasks, run `make beat up`. To run and enable the sms-provider-stub, run `make sms-provider-stub up`. These can be combined to `make beat antivirus sms-provider-stub up` to run *everything*.
 
 ### Accessing your local Notify services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,8 @@ services:
       - private/notify-api.env
     environment:
       - ANTIVIRUS_ENABLED
+      - MMG_URL
+      - FIRETEXT_URL
     depends_on:
       db:
         condition: service_healthy
@@ -306,6 +308,26 @@ services:
     restart: always
     networks:
       apps:
+
+  sms-provider-stub:
+    image: sms-provider-stub
+    container_name: sms-provider-stub
+    profiles:
+      - sms-provider-stub
+    build:
+      context: ../notifications-sms-provider-stub
+      dockerfile: docker/Dockerfile
+    ports:
+      - "6300:6300"
+    stdin_open: true
+    tty: true
+    environment:
+      - FIRETEXT_CALLBACK_URL=http://notify-api.localhost:6011/notifications/sms/firetext
+      - MMG_CALLBACK_URL=http://notify-api.localhost:6011/notifications/sms/mmg
+    networks:
+      apps:
+        aliases:
+          - notify.localhost
 
 networks:
   db:


### PR DESCRIPTION
Should be very rare that devs need to use this (only if they are working on the sms stub itself) but it is nice to be able to see that the stub works when running it locally and plugging it into the other apps.

Hopefully I haven't missed anything else needed in here. I've tried to copy the pattern of the other containers.

Given how rarely it will be used, I didn't end up giving it a nice domain, you can just access the sms provider stub on http://localhost:6300 on your browser still.