### PR TITLE
Remove "version" from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:
     image: postgres:15-bullseye


### PR DESCRIPTION
This parameter is obsolete now and was giving a warning.