### PR TITLE
Add `PORT` env var for document download apps

### DIFF
--- a/document-download-api.env.tmpl
+++ b/document-download-api.env.tmpl
@@ -4,6 +4,7 @@ FLASK_APPLICATION=application.py
 FLASK_DEBUG=1
 WERKZEUG_DEBUG_PIN=off
 
+PORT=7000
 SERVER_NAME=api.document-download.localhost:7000
 FRONTEND_HOSTNAME=frontend.document-download.localhost:7001
 DOCUMENT_DOWNLOAD_API_HOSTNAME=api.document-download.localhost:7000

--- a/document-download-frontend.env.tmpl
+++ b/document-download-frontend.env.tmpl
@@ -4,6 +4,7 @@ FLASK_DEBUG=1
 WERKZEUG_DEBUG_PIN=off
 NOTIFY_ENVIRONMENT=development
 
+PORT=7001
 SERVER_NAME=frontend.document-download.localhost:7001
 
 API_HOST_NAME=http://notify-api.localhost:6011


### PR DESCRIPTION
The command for both was moved to be a script in
their repos in this pull request:

https://github.com/alphagov/notifications-local/pull/17

The `entrypoint.sh` script references the `PORT`
environment variable. When running outside of
notifications-local, `entrypoint.sh` is run by
other scripts, which set `PORT`, for example:

https://github.com/alphagov/document-download-frontend/blob/2a493399c1bd6a64a1cdbef4adea187f90da1aba/scripts/run_locally_with_docker.sh

In notifications-local, we run `entrypoint.sh`
directly so need to set it ourselves. This does
that by adding it to the env var templates for
those apps.

Note: all users who have already generated their
env var files (in `./private`) will need to add
this manually.