### PR TITLE
Update docker compose to use amd64 unit-tests-image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       apps:
 
   notify-admin:
+    platform: linux/amd64
     image: notifications-admin
     container_name: notify-admin
     volumes:
@@ -188,6 +189,7 @@ services:
           - api.document-download.localhost
 
   document-download-frontend:
+    platform: linux/amd64
     image: document-download-frontend
     container_name: document-download-frontend
     volumes:


### PR DESCRIPTION
After recent change tp remove sh file, the new unit-tests-image does not work on mac because of the ghcr image only support amd64. We force to use amd64 platform.