### PR TITLE
generate-env-files.sh: Use staging credentials instead of preview

### DIFF
--- a/generate-env-files.sh
+++ b/generate-env-files.sh
@@ -23,13 +23,13 @@ export TMPL_AWS_SECRET_ACCESS_KEY="${TMPL_AWS_SECRET_ACCESS_KEY}"
 echo -n "Reading secrets from \`notifications-credentials\` ... "
 export TMPL_MMG_API_KEY=$(pass credentials/mmg | tail -n 6 | grep "API key" | cut -d" " -f3)
 export TMPL_FIRETEXT_API_KEY=$(pass credentials/firetext | tail -n 6 | grep "API key" | cut -d" " -f3)
-export TMPL_ZENDESK_API_KEY=$(pass credentials/preview/ssm/zendesk_api_key)
-export TMPL_NOTIFY_API_SENTRY_DSN=$(pass credentials/preview/ssm/notifications_api_sentry_dsn)
-export TMPL_NOTIFY_ADMIN_SENTRY_DSN=$(pass credentials/preview/ssm/notifications_admin_sentry_dsn)
-export TMPL_DOCUMENT_DOWNLOAD_API_SENTRY_DSN=$(pass credentials/preview/ssm/document_download_api_sentry_dsn)
-export TMPL_DOCUMENT_DOWNLOAD_FRONTEND_SENTRY_DSN=$(pass credentials/preview/ssm/document_download_frontend_sentry_dsn)
-export TMPL_TEMPLATE_PREVIEW_API_SENTRY_DSN=$(pass credentials/preview/ssm/template_preview_sentry_dsn)
-export TMPL_ANTIVIRUS_API_SENTRY_DSN=$(pass credentials/preview/ssm/notifications_antivirus_sentry_dsn)
+export TMPL_ZENDESK_API_KEY=$(pass credentials/staging/ssm/zendesk_api_key)
+export TMPL_NOTIFY_API_SENTRY_DSN=$(pass credentials/staging/ssm/notifications_api_sentry_dsn)
+export TMPL_NOTIFY_ADMIN_SENTRY_DSN=$(pass credentials/staging/ssm/notifications_admin_sentry_dsn)
+export TMPL_DOCUMENT_DOWNLOAD_API_SENTRY_DSN=$(pass credentials/staging/ssm/document_download_api_sentry_dsn)
+export TMPL_DOCUMENT_DOWNLOAD_FRONTEND_SENTRY_DSN=$(pass credentials/staging/ssm/document_download_frontend_sentry_dsn)
+export TMPL_TEMPLATE_PREVIEW_API_SENTRY_DSN=$(pass credentials/staging/ssm/template_preview_sentry_dsn)
+export TMPL_ANTIVIRUS_API_SENTRY_DSN=$(pass credentials/staging/ssm/notifications_antivirus_sentry_dsn)
 echo -e "Done.\n"
 
 mkdir -p private


### PR DESCRIPTION
https://trello.com/c/I7l8IwKj/1295-delete-the-preview-environment-🎉

We've deleted the preview environment and its associated credentials.