### PR TITLE
Added environment variables for S3 buckets in admin

### DIFF
--- a/notify-admin.env.tmpl
+++ b/notify-admin.env.tmpl
@@ -20,6 +20,17 @@ ANTIVIRUS_API_HOST=http://antivirus-api.localhost:6016
 
 ZENDESK_API_KEY=${TMPL_ZENDESK_API_KEY}
 
+
+S3_BUCKET_DOCUMENT_DOWNLOAD_LONG_TERM_FILE_STORAGE=development-template-email-files
+S3_BUCKET_REPORT_REQUESTS_DOWNLOAD=development-report-requests-download
+S3_BUCKET_LETTER_ATTACHMENTS=development-letter-attachments
+S3_BUCKET_PRECOMPILED_ORIGINALS_BACKUP_LETTERS=development-precompiled-originals-backup-letters
+S3_BUCKET_TRANSIENT_UPLOADED_LETTERS=development-transient-uploaded-letters
+S3_BUCKET_MOU=development-mou
+S3_BUCKET_LOGO_UPLOAD=public-logos-development
+S3_BUCKET_CONTACT_LIST_UPLOAD=development-contact-list
+S3_BUCKET_CSV_UPLOAD=development-notifications-csv-upload
+
 SENTRY_ENABLED=0
 SENTRY_DSN=${TMPL_NOTIFY_ADMIN_SENTRY_DSN}
 SENTRY_ERRORS_SAMPLE_RATE=1


### PR DESCRIPTION
These are currently undefined so anything that requires an S3 bucket fails when using notifications-local. This only adds the bucket environment variables for admin, they are still missing for the other apps.