### PR TITLE
Add WAL configuration to local databases

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,6 @@
+FROM postgres:15-bullseye
+
+RUN apt-get update \
+    && apt-get install -y postgresql-15-wal2json \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   db:
     image: postgres:15-bullseye
     container_name: db
+    command: >
+      postgres
+        -c wal_level=logical
+        -c max_replication_slots=10
+        -c max_wal_senders=10
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
-    image: postgres:15-bullseye
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
     container_name: db
     command: >
       postgres


### PR DESCRIPTION
## What

Adds in WAL configurations so that the Write ahead log level is `logical` on local databases.

## Why

This is needed to implement WAL2JSON feature on the api service.

For production, this is set on RDS configurations.

`wal_level`=logical - enables logical replication
`max_replication_slots`=10 - allows up to 10 replication slots
`max_wal_senders`=10 - allows up to 10 concurrent WAL sender processes

Documentation about the config can be found here:
https://www.postgresql.org/docs/current/runtime-config-replication.html