### PR TITLE
template-preview-api.env.tmpl: Remove unused STATSD_ENABLED env var

### DIFF
--- a/template-preview-api.env.tmpl
+++ b/template-preview-api.env.tmpl
@@ -6,8 +6,6 @@ SERVER_NAME=template-preview-api.localhost:6013
 FLASK_DEBUG=1
 WERKZEUG_DEBUG_PIN=off
 
-STATSD_ENABLED=
-
 TEMPLATE_PREVIEW_INTERNAL_SECRETS=["my-secret-key"]
 DANGEROUS_SALT=dev-notify-salt
 SECRET_KEY=dev-notify-secret-key


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Removes an unused env var from template-preview-api's env template