### PR TITLE
Add doc download env vars to admin app

### DIFF
--- a/notify-admin.env.tmpl
+++ b/notify-admin.env.tmpl
@@ -20,6 +20,8 @@ ANTIVIRUS_API_HOST=http://antivirus-api.localhost:6016
 
 ZENDESK_API_KEY=${TMPL_ZENDESK_API_KEY}
 
+DOCUMENT_DOWNLOAD_API_HOST=http://api.document-download.localhost:7000
+DOCUMENT_DOWNLOAD_API_HOST_NAME_INTERNAL=http://api.document-download.localhost:7000
 
 S3_BUCKET_DOCUMENT_DOWNLOAD_LONG_TERM_FILE_STORAGE=development-template-email-files
 S3_BUCKET_REPORT_REQUESTS_DOWNLOAD=development-report-requests-download


### PR DESCRIPTION
Admin now talks directly to doc download api, to
run checks against files uploaded as part of the
process for attaching files to emails.

Because of that, it needs these environment
variables to find doc download.

See this pull request for details:

https://github.com/alphagov/notifications-admin/pull/5934

Note: users will need to re-run the
`generate-env-files.sh` script once this is
merged, to ensure the environment variables used
by docker compose include these 2 new ones, as
documented in step 3. of the 'Initial setup'
section of the README.