### PR TITLE
Add `max_slot_wal_keep_size` configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         -c wal_level=logical
         -c max_replication_slots=10
         -c max_wal_senders=10
+        -c max_slot_wal_keep_size=1GB
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
## What

Add `max_slot_wal_keep_size` configuration

## Why

This will ensure that the local environment does not end up eating up storage space if there are no workers processing the WAL messages.

Made based off the following comment:
https://github.com/alphagov/notifications-api/pull/4906#issuecomment-4906490523