### PR TITLE
Make build optional via flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ down: beat antivirus sms-provider-stub
 generate-local-dev-db-fixtures:
 	docker exec -it notify-api flask command functional-test-fixtures
 	docker cp notify-api:/tmp/functional_test_env.sh ../notifications-functional-tests/environment_local.sh
+
+.PHONY: update-repos
+update-repos:
+	sh ./update-and-bootstrap-repos.sh
+
+.PHONY: update-repos-and-build
+update-repos-and-build:
+	sh ./update-and-bootstrap-repos.sh --build

--- a/update-and-bootstrap-repos.sh
+++ b/update-and-bootstrap-repos.sh
@@ -1,16 +1,43 @@
 #!/usr/bin/env bash
 
-repositories=('notifications-api' 'notifications-admin' 'notifications-template-preview' 'document-download-api' 'document-download-frontend' 'notifications-antivirus' 'notifications-utils')
+repositories=(
+    'notifications-api' \
+    'notifications-admin' \
+    'notifications-template-preview' \
+    'document-download-api' \
+    'document-download-frontend' \
+    'notifications-antivirus' \
+    'notifications-utils'
+)
 not_on_main=()
+do_build=false
+full_line=$(printf '%*s' "${COLUMNS:-100}" '' | tr ' ' '-')
+
+for arg in "$@"; do
+    case "$arg" in
+        --build)
+            do_build=true
+            ;;
+    esac
+done
+
+echo "$full_line"
+if [ "$do_build" = true ]; then
+    echo "[info] Pulling and building docker containers for each repository"
+else
+    echo "[info] Pulling latest changes for each repository only (no build)"
+fi
+
+# Pull latest changes for each repository
 for repository in ${repositories[@]}; do
-    echo "Pulling latest changes for $repository"
+    echo "$full_line"
+    echo "[$repository] Pulling latest changes \n"
     (cd ../$repository && \
     current_branch=$(git rev-parse --abbrev-ref HEAD) && \
     if [ "$current_branch" != "main" ]; then
-        echo "Skipping: Not on main branch (repo: $repository, current branch: $current_branch)"
+        echo "[$repository] Skipping: Not on main branch (repo: $repository, current branch: $current_branch)"
         exit 0
-    fi && \
-    git pull && make bootstrap-with-docker) || {
+    fi && git fetch origin main && git pull) || {
         if [ $? -eq 0 ]; then
             not_on_main+=("$repository")
         else
@@ -19,7 +46,25 @@ for repository in ${repositories[@]}; do
     }
 done
 
+if [ "$do_build" = true ]; then
+    # Build docker containers for each repository
+    for repository in ${repositories[@]}; do
+        echo "$full_line"
+        echo "[$repository] Building docker container \n"
+        (cd ../$repository && make bootstrap-with-docker) || {
+            if [ $? -eq 0 ]; then
+                not_on_main+=("$repository")
+            else
+                exit 1
+            fi
+        }
+    done
+fi
+
 if [ ${#not_on_main[@]} -gt 0 ]; then
     echo ""
     echo "Skipped repos (not on main branch): ${not_on_main[*]}"
 fi
+
+echo "$full_line"
+


### PR DESCRIPTION
## What

- Make build optional via flag
- Make command line output more prettier
- Add make commands to make things easier to run

## Why

This is to allow quick update of repos without the lengthy docker build process which is not always needed.

## Before

```sh
~/S/notifications-local (main)> sh ./update-and-bootstrap-repos.sh
Pulling latest changes for notifications-api
Already up to date.
docker build -f docker/Dockerfile --target test -t notifications-api .
[+] Building 7.1s (7/32)                                                                                                 docker:desktop-linux
 .....
```

## After

```sh
~/S/notifications-local (update-script-for-bootstrapping)> make update-repos
sh ./update-and-bootstrap-repos.sh
----------------------------------------------------------------------------------------------------
[info] Pulling latest changes for each repository only (no build)
----------------------------------------------------------------------------------------------------
[notifications-api] Pulling latest changes 

From github.com:alphagov/notifications-api
 * branch                main       -> FETCH_HEAD
Already up to date.
----------------------------------------------------------------------------------------------------
[notifications-admin] Pulling latest changes 

From github.com:alphagov/notifications-admin
 * branch                main       -> FETCH_HEAD
Already up to date.
----------------------------------------------------------------------------------------------------

...
```